### PR TITLE
Update oven.py

### DIFF
--- a/lib/oven.py
+++ b/lib/oven.py
@@ -133,6 +133,9 @@ class Oven (threading.Thread):
                         self.reset()
                 else:
                     temperature_count = 0
+                    
+                #Capture the last temperature value.  This must be done before set_heat, since there is a sleep in there now.
+                last_temp = self.temp_sensor.temperature
                 
                 self.set_heat(pid)
                 
@@ -151,8 +154,7 @@ class Oven (threading.Thread):
                 if self.runtime >= self.totaltime:
                     self.reset()
 
-            #Capture the last temperature value
-            last_temp = self.temp_sensor.temperature
+            
             if pid > 0:
                 time.sleep(self.time_step * (1 - pid))
             else:


### PR DESCRIPTION
Added proportional output functionality by turning the oven (SSR) on for a portion of the time_step determined by the pid loop output. So, if time_step = 1, and the pid loop is calling for .3 heat, the SSR will be on for .3 seconds, and off for .7 seconds.  I did this by adding an additional sleep.  Previously, the SSR would be on whenever pid > 0.

Also, this is my first github pull request.  I'm not sure if I'm doing this right, or if anyone would find these changes useful, so feel free to ignore.