### PR TITLE
Update startup script to use python3 explicitly

### DIFF
--- a/lib/init/reflow
+++ b/lib/init/reflow
@@ -17,7 +17,7 @@ export HOME
 case "$1" in
     start)
         echo "Starting Reflow Server"
-        /home/pi/picoReflow/picoreflowd.py  2>&1 &
+        python3 /home/pi/picoReflow/picoreflowd.py  2>&1 &
     ;;
     stop)
         echo "Stopping Reflow Server"


### PR DESCRIPTION
This prevents the script failing when defaulting python2 when running .py files.